### PR TITLE
[JCN-497-support-array-type-attributes] - add support to array attrib…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install --dev @aws-sdk/client-sns@3
 > The event `content` will be JSON-stringified before sending
 
 > The event `attributes` can be either Strings or Arrays.  It's important to note that using other data types may cause issues or inconsistencies in the implemented filter policies. Ensure that the values provided for the attributes are always of the expected type to avoid errors in message processing.
-***Note: This behavior applies from version 1.0.3 onward.***
+***Note: This behavior applies from version 1.1.0 onward.***
 
 #### Publish single event
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ npm install --dev @aws-sdk/client-sns@3
 
 > The event `content` will be JSON-stringified before sending
 
+> The event `attributes` can be either Strings or Arrays.  It's important to note that using other data types may cause issues or inconsistencies in the implemented filter policies. Ensure that the values provided for the attributes are always of the expected type to avoid errors in message processing.
+
 #### Publish single event
 
 ```js
@@ -41,7 +43,7 @@ const result = await snsTrigger.publishEvent('topicName', {
 	},
 	attributes: {
 		source: 'user',
-		platform: 'mobile'
+		platforms: ['mobile', 'web']
 	}
 });
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ npm install --dev @aws-sdk/client-sns@3
 > The event `content` will be JSON-stringified before sending
 
 > The event `attributes` can be either Strings or Arrays.  It's important to note that using other data types may cause issues or inconsistencies in the implemented filter policies. Ensure that the values provided for the attributes are always of the expected type to avoid errors in message processing.
+***Note: This behavior applies from version 1.0.3 onward.***
 
 #### Publish single event
 

--- a/lib/sns-trigger.js
+++ b/lib/sns-trigger.js
@@ -198,8 +198,8 @@ module.exports = class SnsTrigger {
 			hasAttributes = true;
 			Object.entries(attributes).forEach(([key, value]) => {
 				parsedAttributes[key] = {
-					DataType: 'String',
-					StringValue: value
+					DataType: Array.isArray(value) ? 'String.Array' : 'String',
+					StringValue: Array.isArray(value) ? JSON.stringify(value) : value
 				};
 			});
 		}

--- a/tests/sns-trigger.js
+++ b/tests/sns-trigger.js
@@ -176,7 +176,8 @@ describe('SnsTrigger', () => {
 					foo: 'bar'
 				},
 				attributes: {
-					foo: 'bar'
+					foo: 'bar',
+					arrayAttribute: ['option1', 'option2']
 				},
 				subject: 'test',
 				messageGroupId: 'group1',
@@ -198,6 +199,10 @@ describe('SnsTrigger', () => {
 					foo: {
 						DataType: 'String',
 						StringValue: 'bar'
+					},
+					arrayAttribute: {
+						DataType: 'String.Array',
+						StringValue: JSON.stringify(['option1', 'option2'])
 					}
 				},
 				Subject: 'test',


### PR DESCRIPTION
Link de la tarea

Epica: https://janiscommerce.atlassian.net/browse/JCN-496

Subtarea: https://janiscommerce.atlassian.net/browse/JCN-497

## Descripción del requerimiento
Actualmente el paquete asume que todos los atributos cargados al mensaje son de tipo String. Esto hace que en escenarios en los que, por ejemplo se necesite que el mensaje sea filtrado por multiples recursos con criterios diferentes, la filter policy no pueda procesar correctamente esos atributos ya que a pesar de tener un value de tipo Array, su data type se interpreta como string, lo cual termina rompiendo la condicion de igualdad que busca el filtro.
Ej: Si se publica un mensaje comunicando la actualizacion de un producto que se vende en 3 plataformas, el unico camino que tenemos hoy es creando 3 mensajes, uno por plataforma. Si el paquete formateara correctamente los atributos

Para esto se debe modificar el paquete https://www.npmjs.com/package/@janiscommerce/sns para que admita atributos de tipo array.